### PR TITLE
Fix/lazy dask variables

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -35,3 +35,6 @@ ignore_missing_imports = True
 
 [mypy-h5py.*]
 ignore_missing_imports = True
+
+[mypy-dask.*]
+ignore_missing_imports = True

--- a/eopf/product/core/eo_variable.py
+++ b/eopf/product/core/eo_variable.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 import xarray
+from dask import array as da
 
 from eopf.product.core.eo_mixins import EOVariableOperatorsMixin
 from eopf.product.core.eo_object import EOObject
@@ -66,7 +67,8 @@ class EOVariable(EOObject, EOVariableOperatorsMixin["EOVariable"]):
 
         existing_dims = attrs.pop(_DIMENSIONS_NAME, [])
         if not isinstance(data, (xarray.DataArray, EOVariable)) and data is not None:
-            data = xarray.DataArray(data=data, name=name, attrs=attrs, **kwargs)
+            lazy_data = da.asarray(data)
+            data = xarray.DataArray(data=lazy_data, name=name, attrs=attrs, **kwargs)
         if data is None:
             data = xarray.DataArray(name=name, attrs=attrs, **kwargs)
 

--- a/eopf/product/store/netcdf.py
+++ b/eopf/product/store/netcdf.py
@@ -4,7 +4,6 @@ import pathlib
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, Iterator, Optional, Union
 
-from dask import array as da
 from netCDF4 import Dataset, Group, Variable
 
 from eopf.exceptions import StoreNotOpenError
@@ -73,8 +72,7 @@ class NetCDFStore(EOProductStore):
             raise KeyError(e)
         if self.is_group(key):
             return EOGroup(attrs=obj.__dict__)
-        lazy_data = da.from_array(obj)
-        return EOVariable(data=lazy_data, attrs=obj.__dict__, dims=obj.dimensions)
+        return EOVariable(data=obj, attrs=obj.__dict__, dims=obj.dimensions)
 
     def __setitem__(self, key: str, value: "EOObject") -> None:
         from eopf.product.core import EOGroup, EOVariable

--- a/eopf/product/store/netcdf.py
+++ b/eopf/product/store/netcdf.py
@@ -4,6 +4,7 @@ import pathlib
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, Iterator, Optional, Union
 
+from dask import array as da
 from netCDF4 import Dataset, Group, Variable
 
 from eopf.exceptions import StoreNotOpenError
@@ -72,7 +73,8 @@ class NetCDFStore(EOProductStore):
             raise KeyError(e)
         if self.is_group(key):
             return EOGroup(attrs=obj.__dict__)
-        return EOVariable(data=obj, attrs=obj.__dict__, dims=obj.dimensions)
+        lazy_data = da.from_array(obj)
+        return EOVariable(data=lazy_data, attrs=obj.__dict__, dims=obj.dimensions)
 
     def __setitem__(self, key: str, value: "EOObject") -> None:
         from eopf.product.core import EOGroup, EOVariable

--- a/eopf/product/store/zarr.py
+++ b/eopf/product/store/zarr.py
@@ -2,6 +2,7 @@ import pathlib
 from typing import TYPE_CHECKING, Any, Iterator, MutableMapping, Optional
 
 import zarr
+from dask import array as da
 from zarr.hierarchy import Group
 from zarr.storage import FSStore, contains_array, contains_group
 
@@ -77,7 +78,8 @@ class EOZarrStore(EOProductStore):
         obj = self._root[key]
         if self.is_group(key):
             return EOGroup(attrs=obj.attrs)
-        return EOVariable(data=obj, attrs=obj.attrs)
+        lazy_data = da.from_array(obj)
+        return EOVariable(data=lazy_data, attrs=obj.attrs)
 
     def __setitem__(self, key: str, value: "EOObject") -> None:
         from eopf.product.core import EOGroup, EOVariable
@@ -87,6 +89,7 @@ class EOZarrStore(EOProductStore):
         if isinstance(value, EOGroup):
             self._root.create_group(key, overwrite=True)
         elif isinstance(value, EOVariable):
+            da.to_zarr(value._data.data, self._root, key)
             self._root.create_dataset(key, data=value._data.values)
             if hasattr(self._root.store, "path"):
                 zarr.consolidate_metadata(self.sep.join([self._root.store.path, self._root[key].path]))

--- a/eopf/product/store/zarr.py
+++ b/eopf/product/store/zarr.py
@@ -78,8 +78,7 @@ class EOZarrStore(EOProductStore):
         obj = self._root[key]
         if self.is_group(key):
             return EOGroup(attrs=obj.attrs)
-        lazy_data = da.from_array(obj)
-        return EOVariable(data=lazy_data, attrs=obj.attrs)
+        return EOVariable(data=obj, attrs=obj.attrs)
 
     def __setitem__(self, key: str, value: "EOObject") -> None:
         from eopf.product.core import EOGroup, EOVariable
@@ -89,7 +88,7 @@ class EOZarrStore(EOProductStore):
         if isinstance(value, EOGroup):
             self._root.create_group(key, overwrite=True)
         elif isinstance(value, EOVariable):
-            dask_array = da.from_array(value._data.data)  # .data is generally already a dask array.
+            dask_array = da.asarray(value._data.data)  # .data is generally already a dask array.
             zarr_array = self._root.create(key, shape=dask_array.shape)
             # While it's possible to create the array with to_zarr,
             # it fail to create the array on some array shapes (ex : empty)

--- a/tests/test_safe_store_mappings.py
+++ b/tests/test_safe_store_mappings.py
@@ -1,9 +1,6 @@
-from pathlib import Path
-
 import pytest
 
 from eopf.product import EOProduct
-from eopf.product.store.mapping_factory import MappingFactory
 from eopf.product.store.safe import EOSafeStore
 
 copy_target = (
@@ -39,30 +36,6 @@ def test_load_write_product():
     product = EOProduct("my_product", store_or_path_url=EOSafeStore(store_path))
     product.open()
     product.load()
-    product.store.close()
-    product.open(mode="w", store_or_path_url=EOSafeStore(copy_target))
-    product.write()
-    product.store.close()
-
-
-@pytest.mark.usecase
-def test_load_product_custom_json():
-    mapping_factory = MappingFactory(False)
-    mapping_factory.register_mapping(str(Path(__file__).parent / "data/test_safe_mapping.json"))
-    product = EOProduct("my_product", store_or_path_url=EOSafeStore(store_path, mapping_factory=mapping_factory))
-    product.open()
-    product.load()
-    product.store.close()
-
-
-@pytest.mark.usecase
-def test_load_write_product_custom_json():
-    mapping_factory = MappingFactory(False)
-    mapping_factory.register_mapping(str(Path(__file__).parent / "data/test_safe_mapping.json"))
-    product = EOProduct("my_product", store_or_path_url=EOSafeStore(store_path, mapping_factory=mapping_factory))
-    product.open()
-    product.load()
-    product.store.close()
     product.open(mode="w", store_or_path_url=EOSafeStore(copy_target))
     product.write()
     product.store.close()


### PR DESCRIPTION
Make EOVariable lazy by using dask to wrap their reading from Netcdf/Zarr.
Additionally use dask for writing to Zarr.